### PR TITLE
add function `full` and `full_like`

### DIFF
--- a/sharedmem/sharedmem.py
+++ b/sharedmem/sharedmem.py
@@ -110,7 +110,9 @@ __all__ = ['set_debug', 'get_debug',
         'SlaveException', 'StopProcessGroup',
         'background',
         'MapReduce', 'MapReduceByThread',
-        'empty', 'empty_like', 'copy',
+        'empty', 'empty_like', 
+        'full', 'full_like',
+        'copy',
         ]
 
 import os
@@ -699,12 +701,28 @@ def empty_like(array, dtype=None):
     """ Create a shared memory array from the shape of array.
     """
     if dtype is None: dtype = array.dtype
-    return anonymousmemmap(numpy.broadcast(array, array).shape, dtype)
+    return anonymousmemmap(numpy.asarray(array).shape, dtype)
 
 def empty(shape, dtype='f8'):
     """ Create an empty shared memory array.
     """
     return anonymousmemmap(shape, dtype)
+
+def full_like(array, value, dtype=None):
+    """ Create a shared memory array with the same shape and type as a given array.
+    """
+    if dtype is None: 
+        dtype = numpy.asarray(array).dtype
+    shared = anonymousmemmap(numpy.asarray(array).shape, dtype)
+    shared[:] = value
+    return shared
+    
+def full(shape, value, dtype='f8'):
+    """ Create a shared memory array of given shape and type, filled with `value`.
+    """
+    shared = anonymousmemmap(shape, dtype)
+    shared[:] = value
+    return shared
 
 def copy(a):
     """ Copy an array to the shared memory. 

--- a/sharedmem/sharedmem.py
+++ b/sharedmem/sharedmem.py
@@ -700,7 +700,8 @@ class MapReduce(object):
 def empty_like(array, dtype=None):
     """ Create a shared memory array from the shape of array.
     """
-    if dtype is None: dtype = array.dtype
+    if dtype is None: 
+        dtype = numpy.asarray(array).dtype
     return anonymousmemmap(numpy.asarray(array).shape, dtype)
 
 def empty(shape, dtype='f8'):

--- a/sharedmem/sharedmem.py
+++ b/sharedmem/sharedmem.py
@@ -700,9 +700,10 @@ class MapReduce(object):
 def empty_like(array, dtype=None):
     """ Create a shared memory array from the shape of array.
     """
+    array = numpy.asarray(array)
     if dtype is None: 
-        dtype = numpy.asarray(array).dtype
-    return anonymousmemmap(numpy.asarray(array).shape, dtype)
+        dtype = array.dtype
+    return anonymousmemmap(array.shape, dtype)
 
 def empty(shape, dtype='f8'):
     """ Create an empty shared memory array.
@@ -710,18 +711,16 @@ def empty(shape, dtype='f8'):
     return anonymousmemmap(shape, dtype)
 
 def full_like(array, value, dtype=None):
-    """ Create a shared memory array with the same shape and type as a given array.
+    """ Create a shared memory array with the same shape and type as a given array, filled with `value`.
     """
-    if dtype is None: 
-        dtype = numpy.asarray(array).dtype
-    shared = anonymousmemmap(numpy.asarray(array).shape, dtype)
+    shared = empty_like(array, dtype)
     shared[:] = value
     return shared
     
 def full(shape, value, dtype='f8'):
     """ Create a shared memory array of given shape and type, filled with `value`.
     """
-    shared = anonymousmemmap(shape, dtype)
+    shared = empty(shape, dtype)
     shared[:] = value
     return shared
 


### PR DESCRIPTION
Add two function `full` and `full_like`, they are more convenient sometimes.
If you like it, I'll add `ones` and `zeros` latter.

I don't know why you use `numpy.broadcast(array, array).shape` to get the array shape. What's the difference with `numpy.asarray(array).shape`? As far as I see it seems the latter one is more clear? 