### PR TITLE
use documented method instead of hidden method to get ctype from Numpy 1.16

### DIFF
--- a/sharedmem/sharedmem.py
+++ b/sharedmem/sharedmem.py
@@ -827,7 +827,7 @@ def fromiter(iter, dtype, count=None):
 
 def __unpickle__(ai, dtype):
     dtype = numpy.dtype(dtype)
-    tp = numpy.ctypeslib._typecodes['|u1']
+    tp = numpy.ctypeslib.as_ctypes_type(numpy.dtype('|u1'))
 
     # if there are strides, use strides, otherwise the stride is the itemsize of dtype
     if ai['strides']:


### PR DESCRIPTION
Thanks for sharing this great toolbox.

However, current implementation gives error when unpickling. My setup:
python 3.7.3
numpy 1.16.2
sharedmem 0.3.5